### PR TITLE
feat: add support for GetTemporalTransform

### DIFF
--- a/include/dua_tf_server/dua_tf_server.hpp
+++ b/include/dua_tf_server/dua_tf_server.hpp
@@ -36,6 +36,7 @@
 #include <geometry_msgs/msg/transform_stamped.hpp>
 
 #include <dua_geometry_interfaces/srv/get_transform.hpp>
+#include <dua_geometry_interfaces/srv/get_temporal_transform.hpp>
 #include <dua_geometry_interfaces/srv/transform_pose.hpp>
 
 #define UNUSED(arg) (void)(arg)
@@ -49,6 +50,7 @@ using geometry_msgs::msg::PoseStamped;
 using geometry_msgs::msg::TransformStamped;
 
 using dua_geometry_interfaces::srv::GetTransform;
+using dua_geometry_interfaces::srv::GetTemporalTransform;
 using dua_geometry_interfaces::srv::TransformPose;
 
 /**
@@ -105,6 +107,7 @@ private:
   // ######################################  Callback groups  ######################################
   rclcpp::CallbackGroup::SharedPtr pose_cgroup_;
   rclcpp::CallbackGroup::SharedPtr get_transform_cgroup_;
+  rclcpp::CallbackGroup::SharedPtr get_temporal_transform_cgroup_;
   rclcpp::CallbackGroup::SharedPtr transform_pose_cgroup_;
 
   /**
@@ -135,6 +138,7 @@ private:
 
   // ######################################  Service servers  ######################################
   rclcpp::Service<GetTransform>::SharedPtr get_transform_srv_;
+  rclcpp::Service<GetTemporalTransform>::SharedPtr get_temporal_transform_srv_;
   rclcpp::Service<TransformPose>::SharedPtr transform_pose_srv_;
 
   /**
@@ -151,6 +155,16 @@ private:
   void get_transform_callback(
     GetTransform::Request::SharedPtr req,
     GetTransform::Response::SharedPtr resp);
+
+  /**
+   * @brief Gets the transform between a source frame at one time to a target frame at another time.
+   *
+   * @param req Request.
+   * @param resp Response.
+   */
+  void get_temporal_transform_callback(
+    GetTemporalTransform::Request::SharedPtr req,
+    GetTemporalTransform::Response::SharedPtr resp);
 
   /**
    * @brief Transforms a pose from a source frame to a target frame.

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>dua_tf_server</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>Centralized server that manages and provides transformations between coordinate frames.</description>
   <maintainer email="info@dotxautomation.com">dotX Automation</maintainer>
   <license>Apache-2.0</license>

--- a/src/dua_tf_server/dua_tf_server.cpp
+++ b/src/dua_tf_server/dua_tf_server.cpp
@@ -48,6 +48,7 @@ void TFServerNode::init_cgroups()
 {
   pose_cgroup_ = dua_create_reentrant_cgroup();
   get_transform_cgroup_ = dua_create_reentrant_cgroup();
+  get_temporal_transform_cgroup_ = dua_create_reentrant_cgroup();
   transform_pose_cgroup_ = dua_create_reentrant_cgroup();
 }
 
@@ -89,6 +90,16 @@ void TFServerNode::init_service_servers()
       std::placeholders::_1,
       std::placeholders::_2),
     get_transform_cgroup_);
+
+  // Create the GetTemporalTransform service server
+  get_temporal_transform_srv_ = dua_create_service_server<GetTemporalTransform>(
+    "~/get_temporal_transform",
+    std::bind(
+      &TFServerNode::get_temporal_transform_callback,
+      this,
+      std::placeholders::_1,
+      std::placeholders::_2),
+    get_temporal_transform_cgroup_);
 
   // Create the TransformPose service server
   transform_pose_srv_ = dua_create_service_server<TransformPose>(


### PR DESCRIPTION
Add support for the service GetTemporalTransform to get the transform between a source frame at one time to a target frame at another time.