### PR TITLE
fix: TransformPose can use the latest transform instead of the tstamp…

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>dua_tf_server</name>
-  <version>1.0.7</version>
+  <version>1.0.8</version>
   <description>Centralized server that manages and provides transformations between coordinate frames.</description>
   <maintainer email="info@dotxautomation.com">dotX Automation</maintainer>
   <license>Apache-2.0</license>

--- a/src/dua_tf_server/dua_tf_server_service_servers.cpp
+++ b/src/dua_tf_server/dua_tf_server_service_servers.cpp
@@ -56,19 +56,17 @@ void TFServerNode::transform_pose_callback(
   const rclcpp::Duration timeout = req->timeout;
 
   // Get the transform
-  CommandResultStamped::_result_type result;
-  geometry_msgs::msg::TransformStamped tf_msg;
+  uint8_t result;
+  geometry_msgs::msg::TransformStamped tf_msg{};
   compute_transform(
     source_time, source_frame, target_time, target_frame, timeout,
     result, tf_msg);
 
-  // Transform the pose
-  if (result == CommandResultStamped::SUCCESS) {
+  // Transform the pose; this handles all the cases
+  if (result != CommandResultStamped::ERROR) {
     tf2::doTransform(req->source_pose, resp->target_pose, tf_msg);
-    resp->result.result = CommandResultStamped::SUCCESS;
-  } else {
-    resp->result.result = result;
   }
+  resp->result.result = result;
 }
 
 } // namespace dua_tf_server


### PR DESCRIPTION
This pull request updates the `dua_tf_server` package version and refactors the logic in the `transform_pose_callback` function to improve how pose transformations and error handling are performed.

tl;dr `FAILED` is now a viable result code, meaning that poses can be transformed according to the latest available TF and not the specifically requested one; the caller then has to decide whether this result is acceptable or not.

Version update:

* Bumped the package version from `1.0.7` to `1.0.8` in `package.xml`.

Refactoring and logic improvement in pose transformation:

* Simplified the result handling in `TFServerNode::transform_pose_callback` by transforming the pose for all non-error results and always setting the response result, making the code more robust and concise.